### PR TITLE
converting par in plotspict.priors to matrix in case that numeric

### DIFF
--- a/spict/R/plotting.R
+++ b/spict/R/plotting.R
@@ -2159,6 +2159,7 @@ plotspict.priors <- function(rep, do.plot=4, stamp=get.version()){
                     nmpl <- add.catchunit(nmpl, inp$catchunit)
                 }
             }
+            par <- matrix(par, ncol = 5)
             for (rr in 1:nrow(par)){
                 nmpl <- sub('log', '', nm)
                 if (nrow(par) > 1){


### PR DESCRIPTION
plotspict.priors() was not working when setting a prior for biomass or fishing mortality or both, because `par` was returned as numeric. Changes make sure that `nrow`  and subsetting work on `par` by converting `par` to matrix under the assumption that `ncol` is always 5 (`ll`, `eat`, `ul`, `sd`, `cv`). You might find a better solution but this worked for me with every prior combination.