### PR TITLE
updating check for large uncertainties in `plotspict.biomass`

### DIFF
--- a/spict/R/plotting.R
+++ b/spict/R/plotting.R
@@ -427,7 +427,8 @@ plotspict.biomass <- function(rep, logax=FALSE, main='Absolute biomass', ylim=NU
         for (i in nindexseq){
             obsI[[i]] <- inp$obsI[[i]]/qest[inp$mapq[i], 2]
         }
-        fininds <- which(Best[, 5] < 5) # Use CV to check for large uncertainties
+        cvCheck <- ifelse(any(Best[,5] <= 5),5,min(Best[,5]))
+        fininds <- which(Best[, 5] <= cvCheck) # Use CV to check for large uncertainties
         BBfininds <- unname(which(is.finite(BB[, 1]) & is.finite(BB[, 3]))) # Use CV to check for large uncertainties
         if (!ylimflag){
             if (length(ylim)!=2){


### PR DESCRIPTION
Fixing the calculation of `fininds` in `plotspict.biomass` to 5 may evoke an error by returning an empty variable which is later used as index. This occurs when no cv is smaller than 5, as it was in my data. Implemented changes use 5 as the cv threshold only if any cv value smaller than 5 exists, otherwise the minimum cv is used to have at least one value limiting the scaling of the plot.