### PR TITLE
Reduce the size of saved retro and manage

### DIFF
--- a/spict/R/manage.R
+++ b/spict/R/manage.R
@@ -122,7 +122,20 @@ prop.F <- function(fac, inpin, repin, maninds, corF=FALSE, dbg=0){
     datint <- make.datin(inpt, dbg=dbg)
     objt <- make.obj(datint, plt, inpt, phase=1)
     objt$fn(repin$opt$par)
-    repmant <- sdreport(objt)
+    ## repmant <- sdreport(objt)
+    verflag <- as.numeric(gsub('[.]', '', as.character(packageVersion('TMB')))) >= 171
+    if (verflag) { 
+      repmant <- sdreport(objt,
+                          getJointPrecision=repin$inp$getJointPrecision,
+                          bias.correct=repin$inp$bias.correct,
+                          bias.correct.control=repin$inp$bias.correct.control,
+                          getReportCovariance=repin$inp$getReportCovariance)
+    } else {
+      repmant <-sdreport(objt,
+                         getJointPrecision=repin$inp$getJointPrecision,
+                         bias.correct=repin$inp$bias.correct,
+                         bias.correct.control=repin$inp$bias.correct.control)
+    }
     repmant$inp <- inpt
     repmant$obj <- objt
     repmant$opt <- list(convergence=0)

--- a/spict/R/retro.R
+++ b/spict/R/retro.R
@@ -29,6 +29,7 @@
 #' plotspict.retro(rep)
 #' @export
 retro <- function(rep, nretroyear=5){
+    verflag <- as.numeric(gsub('[.]', '', as.character(packageVersion('TMB')))) >= 171
     inp1 <- rep$inp
     inpall <- list()
     for (i in 1:nretroyear){
@@ -37,6 +38,12 @@ retro <- function(rep, nretroyear=5){
         inpall[[i]]$ini <- inp1$ini
         inpall[[i]]$priors <- inp1$priors
         inpall[[i]]$phases <- inp1$phases
+        if(verflag) {
+          inpall[[i]]$getReportCovariance <- inp1$getReportCovariance
+        }
+        inpall[[i]]$getJointPrecision <- inp1$getJointPrecision
+        inpall[[i]]$bias.correct <- inp1$bias.correct
+        inpall[[i]]$bias.correct.control <- inp1$bias.correct.control
         #inpall[[i]]$ini <- as.list(rep$par.fixed)
         #inpall[[i]]$dtpredc <- 0
         indsC <- which(inp1$timeC <= inp1$timeC[inp1$nobsC]-i)


### PR DESCRIPTION
Using getReportCovariance = FALSE in the input object is not ignored by retro and manage anymore.