### PR TITLE
building error due to overloaded abs(double) in spict.cpp

### DIFF
--- a/spict/R/plotting.R
+++ b/spict/R/plotting.R
@@ -1895,6 +1895,7 @@ plot.spictcls <- function(x, stamp=get.version(), ...){
             } else {
                 opar <- par(mfrow=c(3, 3), oma=c(0.2, 0.2, 0, 0), mar=c(5,4,2.5,3.5))
             }
+            on.exit(par(opar))
             # Biomass
             plotspict.biomass(rep, logax=logax, stamp='')
             # F
@@ -1914,7 +1915,7 @@ plot.spictcls <- function(x, stamp=get.version(), ...){
             } else {
                 opar <- par(mfrow=c(2, 1), oma=c(0.2, 0.2, 0, 0), mar=c(5,4,2,3.5))
             }
-            on.exit(opar)
+            on.exit(par(opar))
         }
         # Production curve
         plotspict.production(rep, stamp='')
@@ -2156,7 +2157,6 @@ plotspict.retro <- function(rep, stamp=get.version()){
   }
   sel <- function(x) x[,2]
   # Do plots
-  par(mfrow=c(2, 2))
   plot(time[[1]], sel(bs[[1]]), typ='l', ylim=range(sapply(bs, sel)), xlab='Time',
        ylab = expression(B[t]), lwd=1.5)
   polygon(c(time[[1]], rev(time[[1]])), c(bs[[1]][,1], rev(bs[[1]][,3])), col = "#00000022", border = NA)

--- a/spict/src/spict.cpp
+++ b/spict/src/spict.cpp
@@ -411,9 +411,9 @@ Type objective_function<Type>::operator() ()
   //vector<Type> rp(nm);
   //vector<Type> logrp(nm);
   for(int i=0; i<nm; i++){ 
-    rold(i) =  abs(gamma * m(i) / K);
+    rold(i) =  CppAD::abs(gamma * m(i) / K);
     logrold(i) = log(rold(i)); 
-    rc(i) = abs(2.0 * rold(i) * (n - 1.0) / n);
+    rc(i) = CppAD::abs(2.0 * rold(i) * (n - 1.0) / n);
     logrc(i) = log(rc(i)); 
     //rp(i) = abs(r(i) * (n - 1.0));
     //logrp(i) = log(rp(i)); 


### PR DESCRIPTION
Following error when trying to build package from source:

`spict.cpp:416:16: error: call of overloaded ‘abs(double)’ is ambiguous
     rc(i) = abs(2.0 * rold(i) * (n - 1.0) / n);`

Similar issue was reported for `glmmTMB`, see: [issue #208](https://github.com/glmmTMB/glmmTMB/issues/208) and [Fix fedora build issue #208](https://github.com/glmmTMB/glmmTMB/commit/73d7390c73c2dd7de7371476a63031a544e2b8c7)

