### PR TITLE
Fix: plotspict.retro will plot even if some estimates are not finite

### DIFF
--- a/make.description.R
+++ b/make.description.R
@@ -3,7 +3,7 @@ date <- format(Sys.Date(), "%Y-%m-%d")
 cat('Package: spict
 Type: Package
 Title: Stochastic suplus Production model in Continuous-Time (SPiCT)
-Version: 1.2.4
+Version: 1.2.5
 Date:', date, '
 Author: Martin Waever Pedersen
 Maintainer: Martin Waever Pedersen <mawp@dtu.dk>

--- a/spict/DESCRIPTION
+++ b/spict/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: spict
 Type: Package
 Title: Stochastic suplus Production model in Continuous-Time (SPiCT)
-Version: 1.2.4
-Date: 2019-02-20 
+Version: 1.2.5
+Date: 2019-02-27 
 Author: Martin Waever Pedersen
 Maintainer: Martin Waever Pedersen <mawp@dtu.dk>
 Description: Fits a surplus production model to fisheries catch and biomass index data.
@@ -24,5 +24,5 @@ Suggests:
 LazyData: true
 VignetteBuilder: knitr
 GithubRepo: spict
-GithubRef: retroFix 
-GithubSHA1: 331222def739ea5432c87aa976c73725a862e0c4 
+GithubRef: psretro 
+GithubSHA1: e2e914533a586079fb99040b43f86dc0418aee8f 

--- a/spict/R/plotting.R
+++ b/spict/R/plotting.R
@@ -2120,28 +2120,28 @@ plotspict.retro <- function(rep, stamp=get.version()) {
   sel <- function(x) x[,2]
   ## Do plots
   cols <-  c("#000000", "#E41A1C", "#377EB8", "#4DAF4A", "#984EA3", "#FF7F00", "#FFFF33", "#A65628", "#F781BF", "#999999")
-  plot(time[[1]], sel(bs[[1]]), type ='n', ylim=range(sapply(bs, sel)), xlab='Time',
+  plot(time[[1]], sel(bs[[1]]), type ='n', ylim=range(sapply(bs, sel), na.rm = TRUE), xlab='Time',
        ylab = expression(B[t]), lwd=1.5)
   polygon(c(time[[1]], rev(time[[1]])), c(bs[[1]][,1], rev(bs[[1]][,3])), col = "lightgrey", border = NA)
   for (i in seq(nruns)){
     lines(time[[i]], sel(bs[[i]]), col=cols[i], lwd=2)
   }
   box(lwd=1.5)
-  plot(time[[1]], sel(fs[[1]]), typ='n', ylim=range(sapply(fs, sel)), xlab='Time',
+  plot(time[[1]], sel(fs[[1]]), typ='n', ylim=range(sapply(fs, sel), na.rm = TRUE), xlab='Time',
        ylab = expression(F[t]), lwd=1.5)
   polygon(c(time[[1]], rev(time[[1]])), c(fs[[1]][,1], rev(fs[[1]][,3])), col = "lightgrey", border = NA)
   for (i in seq(nruns)){
     lines(time[[i]], sel(fs[[i]]), col=cols[i], lwd=2)
   }
   box(lwd=1.5)
-  plot(time[[1]], sel(bbs[[1]]), typ='n', ylim=range(sapply(bbs, sel)), xlab='Time',
+  plot(time[[1]], sel(bbs[[1]]), typ='n', ylim=range(sapply(bbs, sel), na.rm = TRUE), xlab='Time',
        ylab = expression(B[t]/B[MSY]), lwd=1.5)
   polygon(c(time[[1]], rev(time[[1]])), c(bbs[[1]][,1], rev(bbs[[1]][,3])), col = "lightgrey", border = NA)
   for (i in seq(nruns)){
     lines(time[[i]], sel(bbs[[i]]), col=cols[i], lwd=2)
   }
   box(lwd=1.5)
-  plot(time[[1]], sel(ffs[[1]]), typ='n', ylim=range(sapply(ffs, sel)), xlab='Time',
+  plot(time[[1]], sel(ffs[[1]]), typ='n', ylim=range(sapply(ffs, sel), na.rm = TRUE), xlab='Time',
        ylab = expression(F[t]/F[MSY]), lwd=1.5)
   polygon(c(time[[1]], rev(time[[1]])), c(ffs[[1]][,1], rev(ffs[[1]][,3])), col = "lightgray", border = NA)
   for (i in seq(nruns)){


### PR DESCRIPTION
Fixes #67 

I just include `na.rm = TRUE` in `range` calls that calculate `ylim` in the plots.

Example that breaks with current spict version, but runs with the PR. 
```
library(spict)

set.seed(1)
inp <- list(timeC = 2000:2029, obsC = exp(1:30),
            timeI = 2000:2029, obsI = runif(30))
plotspict.data(inp)
rep <- fit.spict(inp)
retros <- retro(rep, nretroyear = 2)
plotspict.retro(retros)
```
