### PR TITLE
Fix #194

### DIFF
--- a/make.description.R
+++ b/make.description.R
@@ -3,7 +3,7 @@ date <- format(Sys.Date(), "%Y-%m-%d")
 cat('Package: spict
 Type: Package
 Title: Stochastic surplus Production model in Continuous-Time (SPiCT)
-Version: 1.3.8
+Version: 1.3.8.1
 Date:', date, '
 Authors@R: c(person(given="Martin Waever",
                     family="Pedersen",

--- a/spict/DESCRIPTION
+++ b/spict/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: spict
 Type: Package
 Title: Stochastic surplus Production model in Continuous-Time (SPiCT)
-Version: 1.3.8
-Date: 2023-12-08 
+Version: 1.3.8.1
+Date: 2023-12-11 
 Authors@R: c(person(given="Martin Waever",
                     family="Pedersen",
                     email="wpsgodd@gmail.com",

--- a/spict/NEWS.md
+++ b/spict/NEWS.md
@@ -1,3 +1,24 @@
+spict v1.3.9-pre
+============
+
+New features
+
+* A spin-up (burn-in) period can be specified using `inp$nspinup` in number
+  of time steps. It helps stabilise the fit in cases where only catches 
+  are available in the beginning of the time series.
+  
+  
+Minor changes
+
+* On load, `spict` checks if the currently available TMB version is the same
+  as the one that was used to install spict. Gives warning if there is a mismatch.
+
+
+Bug fixes
+
+* `intermediatePeriodCatchList` is now used by the manage function, previously was 
+   ignored
+
 spict v1.3.8 (2023-12-08)
 ============
 

--- a/spict/R/checkinp.R
+++ b/spict/R/checkinp.R
@@ -87,6 +87,7 @@
 #' - Settings/Options/Preferences
 #'
 #' \itemize{
+#' \item{"inp$nspinup"}{Number of time steps used for spin-up (burn-in) period. Default: 0. }
 #' \item{"inp$maninterval"}{ Start and end time of management period. Default: One year interval starting at the beginning of the new year after the last observation. Example: inp$maninterval <- c(2020.25,2021.25)}
 #' \item{"inp$maneval"}{ Time for the estimation of predicted model states (biomass and fishing mortality), which can be used to evaluate the implications of management scenarios. Default: At the end of the management interval \code{inp$maninterval[2]}. Example: inp$maneval <- 2021.25}
 #'  \item{"inp$timepredc"}{ Deprecated: Predict accummulated catch in the interval starting at $timepredc and $dtpredc into the future. Default depends on \code{inp$maninterval}.}
@@ -391,6 +392,8 @@ check.inp <- function(inp, verbose = TRUE, mancheck = TRUE){
     if ("mapqf" %in% names(inp)) inp$nqf <- length(unique(inp$mapqf))
     # Catch related
     if (!"catchunit" %in% names(inp)) inp$catchunit <- ''
+    # Spin-up
+    if (!"nspinup" %in% names(inp)) inp$nspinup <- 0
     # Reporting
     if (!"reportall" %in% names(inp)) inp$reportall <- TRUE
     if (!"reportRel" %in% names(inp)) inp$reportRel <- FALSE
@@ -645,25 +648,27 @@ check.inp <- function(inp, verbose = TRUE, mancheck = TRUE){
         if (inp$eulertype == 'hard'){
             # Hard Euler discretisation
             if (inp$start.in.first.data.point){
-                time <- seq(min(timeobsall), max(inp$timepredi, inp$timepredc+inp$dtpredc),
-                            by=inp$dteuler)
+                time <- seq(min(timeobsall)-inp$nspinup*inp$dteuler, max(inp$timepredi, inp$timepredc+inp$dtpredc),
+                             by=inp$dteuler)
             } else {
                 # Here we take floor of time of first data point
                 # This can sometimes cause problems when estimating the random effect
                 # prior to the first data point, because of no data support
-                time <- seq(floor(min(timeobsall)), max(inp$timepredi, inp$timepredc+inp$dtpredc),
-                            by=inp$dteuler)
+                time <- seq(floor(min(timeobsall))-inp$nspinup*inp$dteuler, max(inp$timepredi, inp$timepredc+inp$dtpredc),
+                             by=inp$dteuler)
             }
             inp$time <- time
         }
         if (inp$eulertype == 'soft'){
             # Include times of observations (including dtc)
-            time <- seq(ceiling(min(timeobsall)), max(inp$timepredi, inp$timepredc+inp$dtpredc), by=inp$dteuler)
+            time <- seq(ceiling(min(timeobsall))-inp$nspinup*inp$dteuler, max(inp$timepredi, inp$timepredc+inp$dtpredc), by=inp$dteuler)
             inp$time <- sort(unique(c(timeobsall, time)))
         }
         if (!inp$eulertype %in% c('soft', 'hard'))
             stop('inp$eulertype must be either "soft" or "hard"!')
     }
+    inp$isspinup <- inp$time < min(timeobsall)
+    inp$timens <- inp$time[!inp$isspinup]
     # Calculate time steps
     inp$dt <- c(diff(inp$time), inp$dteuler)
     inp$ns <- length(inp$time)
@@ -673,6 +678,7 @@ check.inp <- function(inp, verbose = TRUE, mancheck = TRUE){
     inp$indlastobs <- cut(max(c(inp$timeC + inp$dtc - inp$dteuler, unlist(inp$timeI),
                                 inp$timeE + inp$dte - inp$dteuler)),
                           inp$time, right=FALSE, labels=FALSE)
+    inp$indfirstobs <- cut(min(c(inp$timeC, unlist(inp$timeI), inp$timeE)), inp$time, right=FALSE, labels=FALSE)
     inp$indest <- which(inp$time <= inp$timerange[2])
     inp$indpred <- which(inp$time >= inp$timerange[2])
     inp$indCpred <- which(inp$time >= max(inp$timeC + inp$dtc))
@@ -1095,10 +1101,10 @@ check.inp <- function(inp, verbose = TRUE, mancheck = TRUE){
         inp$ini$logm <- log(1)
     }
     # Fill in unspecified (more rarely user defined) model parameter values
-    inp$ini <- set.default(inp$ini, 'logpsi', log(1e-8))
+    inp$ini <- set.default(inp$ini, 'logpsi', log(1e-2))
     inp$ini <- set.default(inp$ini, 'mu', 0)
     if (!"loglambda" %in% names(inp$ini)) inp$ini$loglambda <- log(0.1)
-    if (!"logdelta" %in% names(inp$ini)) inp$ini$logdelta <- log(1e-8) # Strength of mean reversion of OU for F
+    if (!"logdelta" %in% names(inp$ini)) inp$ini$logdelta <- ifelse(inp$effortmodel=="RW",log(1e-18), log(1e-2)) # Strength of mean reversion of OU for F
     if (!"logeta" %in% names(inp$ini)) inp$ini$logeta <- log(0.2) # Mean of OU for F
     if ("logphi" %in% names(inp$ini)){
         if (length(inp$ini$logphi)+1 != dim(inp$splinemat)[2]){

--- a/spict/R/manage.R
+++ b/spict/R/manage.R
@@ -171,6 +171,7 @@ manage <- function(rep, scenarios = 'all',
                                     maneval = maneval,
                                     intermediatePeriodCatch = intermediatePeriodCatch,
                                     intermediatePeriodCatchSDFac = intermediatePeriodCatchSDFac,
+                                    intermediatePeriodCatchList = intermediatePeriodCatchList,
                                     ffac = 1.0, verbose = FALSE, mancheck = FALSE)
         }
         if (3 %in% indscenarios){
@@ -180,6 +181,7 @@ manage <- function(rep, scenarios = 'all',
                                     maneval = maneval,
                                     intermediatePeriodCatch = intermediatePeriodCatch,
                                     intermediatePeriodCatchSDFac = intermediatePeriodCatchSDFac,
+                                    intermediatePeriodCatchList = intermediatePeriodCatchList,
                                     verbose = FALSE, mancheck = FALSE)
         }
         if (4 %in% indscenarios){
@@ -189,6 +191,7 @@ manage <- function(rep, scenarios = 'all',
                                     maneval = maneval,
                                     intermediatePeriodCatch = intermediatePeriodCatch,
                                     intermediatePeriodCatchSDFac = intermediatePeriodCatchSDFac,
+                                    intermediatePeriodCatchList = intermediatePeriodCatchList,
                                     ffac = 0.001, verbose = FALSE, mancheck = FALSE)
         }
         if (5 %in% indscenarios){
@@ -198,6 +201,7 @@ manage <- function(rep, scenarios = 'all',
                                     maneval = maneval,
                                     intermediatePeriodCatch = intermediatePeriodCatch,
                                     intermediatePeriodCatchSDFac = intermediatePeriodCatchSDFac,
+                                    intermediatePeriodCatchList = intermediatePeriodCatchList,
                                     ffac = 0.75, verbose = FALSE, mancheck = FALSE)
         }
         if (6 %in% indscenarios){
@@ -207,6 +211,7 @@ manage <- function(rep, scenarios = 'all',
                                     maneval = maneval,
                                     intermediatePeriodCatch = intermediatePeriodCatch,
                                     intermediatePeriodCatchSDFac = intermediatePeriodCatchSDFac,
+                                    intermediatePeriodCatchList = intermediatePeriodCatchList,
                                     ffac = 1.25, verbose = FALSE, mancheck = FALSE)
         }
         if (7 %in% indscenarios){
@@ -217,6 +222,7 @@ manage <- function(rep, scenarios = 'all',
                                     maneval = maneval,
                                     intermediatePeriodCatch = intermediatePeriodCatch,
                                     intermediatePeriodCatchSDFac = intermediatePeriodCatchSDFac,
+                                    intermediatePeriodCatchList = intermediatePeriodCatchList,
                                     breakpointB = 0.5, verbose = FALSE, mancheck = FALSE)
         }
         if (8 %in% indscenarios){
@@ -227,6 +233,7 @@ manage <- function(rep, scenarios = 'all',
                                     maneval = maneval,
                                     intermediatePeriodCatch = intermediatePeriodCatch,
                                     intermediatePeriodCatchSDFac = intermediatePeriodCatchSDFac,
+				     intermediatePeriodCatchList = intermediatePeriodCatchList,
                                     breakpointB = c(0.3, 0.5),
                                     fractiles = list(catch = 0.35),
                                     verbose = FALSE, mancheck = FALSE)
@@ -488,7 +495,7 @@ mansummary <- function(repin, include.EBinf=FALSE, include.unc=FALSE, include.ab
 #' @param maneval Time at which to evaluate model states. Example: maneval =
 #'     2021.25. Default: NULL.
 #' @param verbose Should detailed outputs be provided (default: TRUE).
-#' @param printTimeline logical; print the management time line (default: FALSE)
+#' @param printTimeLine logical; print the management time line (default: FALSE)
 #' @param mancheck Should the time-dependent objects in \code{inp} be checked
 #'     against the management time and corrected if necessary? (Default: TRUE)
 #'

--- a/spict/R/plotting.R
+++ b/spict/R/plotting.R
@@ -3651,7 +3651,7 @@ plotspict.compare.one <- function(rep, ...,
                                                                        paste(unique(unlist(catchunit)),
                                                                              collapse = " | "))
         }else{
-            indi <- lapply(replist, function(x) which(x$inp$time <= x$inp$timerange[2]))
+            indi <- lapply(replist, function(x) which(x$inp$time <= x$inp$timerange[2] & !x$inp$isspinup))
             xlist <- lapply(1:nrep, function(x) replist[[x]]$inp$time[indi[[x]]])
             ylist <- lapply(1:nrep, function(x) get.par(par, replist[[x]],
                                                         exp = exp, CI = CI)[indi[[x]],1:3])

--- a/spict/R/plotting.R
+++ b/spict/R/plotting.R
@@ -2571,14 +2571,15 @@ plotspict.retro <- function(rep, stamp=get.version(), add.mohn = TRUE, CI = 0.95
         mr <- suppressMessages(mohns_rho(rep, what = c("FFmsy", "BBmsy")))
         mrr <- round(mr, 3)
     }
+    removeSpinupInds <- function(inds, x) setdiff(inds,which(x$inp$isspinup))
     nruns <- length(rep$retro)
     bs <- bbs <- fs <- ffs <- time <- conv <- list()
     for (i in 1:nruns) {
-        bs[[i]] <- get.par('logB', rep$retro[[i]], exp=TRUE, CI = CI)[rep$retro[[i]]$inp$indest, 1:3]
-        bbs[[i]] <- get.par('logBBmsy', rep$retro[[i]], exp=TRUE, CI = CI)[rep$retro[[i]]$inp$indest, 1:3]
-        fs[[i]] <- get.par('logFnotS', rep$retro[[i]], exp=TRUE, CI = CI)[rep$retro[[i]]$inp$indest, 1:3]
-        ffs[[i]] <- get.par('logFFmsynotS', rep$retro[[i]], exp=TRUE, CI = CI)[rep$retro[[i]]$inp$indest, 1:3]
-        time[[i]] <- rep$retro[[i]]$inp$time[rep$retro[[i]]$inp$indest]
+        bs[[i]] <- get.par('logB', rep$retro[[i]], exp=TRUE, CI = CI)[removeSpinupInds(rep$retro[[i]]$inp$indest,rep$retro[[i]]), 1:3]
+        bbs[[i]] <- get.par('logBBmsy', rep$retro[[i]], exp=TRUE, CI = CI)[removeSpinupInds(rep$retro[[i]]$inp$indest,rep$retro[[i]]), 1:3]
+        fs[[i]] <- get.par('logFnotS', rep$retro[[i]], exp=TRUE, CI = CI)[removeSpinupInds(rep$retro[[i]]$inp$indest,rep$retro[[i]]), 1:3]
+        ffs[[i]] <- get.par('logFFmsynotS', rep$retro[[i]], exp=TRUE, CI = CI)[removeSpinupInds(rep$retro[[i]]$inp$indest,rep$retro[[i]]), 1:3]
+        time[[i]] <- rep$retro[[i]]$inp$time[removeSpinupInds(rep$retro[[i]]$inp$indest,rep$retro[[i]])]
         conv[[i]] <- rep$retro[[i]]$opt$convergence
     }
     conv <- ifelse(unlist(conv) == 0, TRUE, FALSE)

--- a/spict/R/plotting.R
+++ b/spict/R/plotting.R
@@ -585,8 +585,8 @@ plotspict.biomass <- function(rep, logax=FALSE, main='Absolute biomass', ylim=NU
             obsI[[i]] <- inp$obsI[[i]]/qest[inp$mapq[i], 2]
         }
         cvCheck <- ifelse(any(Best[,5] <= 5),5,min(Best[,5]))
-        fininds <- which(Best[, 5] <= cvCheck & !inp$isspinup) # Use CV to check for large uncertainties
-        BBfininds <- unname(which(is.finite(BB[, 1]) & is.finite(BB[, 3]) & !inp$isspinup)) # Use CV to check for large uncertainties
+        fininds <- which(Best[, 5] <= cvCheck) # Use CV to check for large uncertainties
+        BBfininds <- unname(which(is.finite(BB[, 1]) & is.finite(BB[, 3]))) # Use CV to check for large uncertainties
         if (!ylimflag){
             if (length(ylim)!=2){
                 ylim <- range(BB[BBfininds, 1:3]/scal*Bmsy[2], Best[fininds, 1:3], Bp[2],
@@ -754,8 +754,8 @@ plotspict.bbmsy <- function(rep, logax=FALSE, main='Relative biomass', ylim=NULL
                     obsI[[i]] <- inp$obsI[[i]]/qest[inp$mapq[i], 2]/Bmsy[1,2]
                 }
             }
-            fininds <- which(apply(BB, 1, function(x) all(is.finite(x))) & !inp$isspinup)
-            BBfininds <- which(is.finite(BB[, 1]) & is.finite(BB[, 3]) & !inp$isspinup)
+            fininds <- which(apply(BB, 1, function(x) all(is.finite(x))))
+            BBfininds <- which(is.finite(BB[, 1]) & is.finite(BB[, 3]))
             if (!ylimflag){
                 if (length(ylim) != 2){
                     ylim <- range(c(lineat, BB[fininds, 1:3], unlist(obsI), 1), na.rm=TRUE)
@@ -1150,6 +1150,7 @@ plotspict.f <- function(rep, logax=FALSE, main='Absolute fishing mortality', yli
             repmax <- rep
             indxmax <- which(inp$time ==  max(inp$time))
         }
+        indxmin <- which.min(!inp$isspinup)
 
         if (tvgflag){
             Fmsy <- get.par('logFmsyvec', repmax, exp=TRUE, CI = CI)
@@ -1179,29 +1180,29 @@ plotspict.f <- function(rep, logax=FALSE, main='Absolute fishing mortality', yli
         clp <- Fest[inp$indpred, 1]
         Fp <- Fest[inp$indpred, 2]
         cup <- Fest[inp$indpred, 3]
-        timef <- inp$time[1:indxmax]
-        Ff <- Fest[1:indxmax, 2]
-        clf <- FF[1:indxmax, 1] #*Fmsy[2]
-        cuf <- FF[1:indxmax, 3] #*Fmsy[2]
+        timef <- inp$time[indxmin:indxmax]
+        Ff <- Fest[indxmin:indxmax, 2]
+        clf <- FF[indxmin:indxmax, 1] #*Fmsy[2]
+        cuf <- FF[indxmin:indxmax, 3] #*Fmsy[2]
 
         #ylimflag <- !is.null(ylim)
         ylimflag <- !is.null(ylim) & length(ylim) == 2 # If FALSE ylim is manually specified
         # Check whether nan values are present in CI limits
         absflag <- length(cu)==0 | all(!is.finite(cu))
         if (absflag){ # if problems with NaN in absolute
-            fininds <- which(is.finite(Ff) & !inp$isspinup)
+            fininds <- which(is.finite(Ff))
             if (!ylimflag){
                 ylim <- range(c(Ff, Fmsy, tail(Fest[, 2],1)), na.rm=TRUE)
             }
         } else { # No problems
-            fininds <- which(apply(cbind(cl, cu), 1, function(x) all(is.finite(x))) & !inp$isspinup[inp$indest])
+            fininds <- which(apply(cbind(cl, cu), 1, function(x) all(is.finite(x))))
             if (!ylimflag){
                 ylim <- range(c(cl[fininds], cu[fininds], tail(Fest[, 2],1)), na.rm=TRUE)
             }
         }
         relflag <-  length(cuf)==0 | all(!is.finite(cuf)) | nlevels(rep$inp$MSYregime)>1
         if (relflag){ # Problems
-            relfininds <- which(is.finite(cuf) & !inp$isspinup)
+            relfininds <- which(is.finite(cuf))
             if (!ylimflag){
                 ylim <- range(ylim, Ff, Fmsy, tail(Fest[, 2],1), na.rm=TRUE)
             }
@@ -1335,6 +1336,7 @@ plotspict.ffmsy <- function(rep, logax=FALSE, main='Relative fishing mortality',
             indest <- indest[-length(indest)]
             indxmax <- which(inp$time ==  max(inp$time)) - 1
         }
+        indxmin <- which.min(!inp$isspinup)
 
         time <- inp$time[indest]
         cl <- FF[indest, 1]
@@ -1344,15 +1346,15 @@ plotspict.ffmsy <- function(rep, logax=FALSE, main='Relative fishing mortality',
         clp <- FF[indpred, 1]
         Fp <- FF[indpred, 2]
         cup <- FF[indpred, 3]
-        timef <- inp$time[1:indxmax]
-        clf <- FF[1:indxmax, 1]
-        Ff <- FF[1:indxmax, 2]
-        cuf <- FF[1:indxmax, 3]
+        timef <- inp$time[indxmin:indxmax]
+        clf <- FF[indxmin:indxmax, 1]
+        Ff <- FF[indxmin:indxmax, 2]
+        cuf <- FF[indxmin:indxmax, 3]
 
         flag <- length(cu) == 0 | all(!is.finite(cu))
         if (flag){
             # CIs don't exist or are not finite
-            fininds <- which(is.finite(Ff) & !inp$isspinup)
+            fininds <- which(is.finite(Ff))
             ys <- c(lineat, Ff[fininds])
         } else {
             fininds <- which(apply(cbind(clf, cuf), 1, function(x) all(is.finite(x))))
@@ -1367,7 +1369,8 @@ plotspict.ffmsy <- function(rep, logax=FALSE, main='Relative fishing mortality',
         }
         xlim <- range(c(inp$timens, tail(inp$time, 1) + 0.5))
         if(manflag) xlim <- get.manlimits(rep,"time")
-        plot(timef[!inp$isspinup], Ff[!inp$isspinup], typ='n', main=main, ylim=ylim, col='blue', ylab=expression(F[t]/F[MSY]),
+        plot(timef, Ff, typ='n', main=main, ylim=ylim,
+             col='blue', ylab=expression(F[t]/F[MSY]),
              xlab=xlab, xlim=xlim, log=log)
         cicol2 <- rgb(0, 0, 1, 0.1)
         if (!flag){
@@ -2290,6 +2293,7 @@ plotspict.btrend <- function(rep, CI = 0.95){
 #'
 #' @export
 plot.spictcls <- function(x, stamp=get.version(), verbose=TRUE, CI = 0.95, ...){
+
     check.rep(x)
     rep <- x
     logax <- FALSE # Take log of relevant axes? default: FALSE

--- a/spict/R/spict.R
+++ b/spict/R/spict.R
@@ -146,6 +146,8 @@ fit.spict <- function(inp, verbose=TRUE, dbg=0){
                 if (sdfailflag){
                     warning('Could not calculate sdreport.\n')
                     rep <- NULL
+                } else {
+                    rep$plsd <- as.list(rep, "Std")
                 }
             }
             if (is.null(rep)){ # If sdreport failed or was not calculated
@@ -225,6 +227,7 @@ make.datin <- function(inp, dbg=0){
                   dtpredeinds=inp$dtpredeinds,
                   dtpredensteps=inp$dtpredensteps,
                   indlastobs=inp$indlastobs,
+                  indfirstobs=inp$indfirstobs,
                   obssrt=inp$obssrt,
                   stdevfacc=inp$stdevfacC,
                   stdevfaci=inp$stdevfacIin,
@@ -254,6 +257,7 @@ make.datin <- function(inp, dbg=0){
                   omega=inp$omega,
                   seasontype=inp$seasontype,
                   efforttype=inp$efforttype,
+                  effortmodel=ifelse(inp$effortmodel=="RW",1,2),
                   timevaryinggrowth=as.numeric(inp$timevaryinggrowth),
                   logmcovflag=as.numeric(inp$logmcovflag),
                   ffacvec=inp$ffacvec,

--- a/spict/R/spict.R
+++ b/spict/R/spict.R
@@ -182,7 +182,8 @@ fit.spict <- function(inp, verbose=TRUE, dbg=0){
     }
     toc <- Sys.time()
     if (!is.null(rep)){
-        rep$computing.time <- as.numeric(toc - tic)
+        rep$spict.version <- spict::get.version()
+        rep$computing.time <- as.numeric(difftime(toc, tic, units = "sec"))
         class(rep) <- "spictcls"
     }
     return(rep)

--- a/spict/R/zzz.R
+++ b/spict/R/zzz.R
@@ -23,5 +23,22 @@
 .onAttach <- function(lib, pkg) {
     #ver <- utils::packageVersion('spict')
     ver <- get.version('spict')
+    checkTMBversion()
     packageStartupMessage(paste0('Welcome to ', ver))
+}
+
+## Code adapted from TMB package
+checkTMBversion <- function() {
+  file <- file.path(system.file(package = "spict"), "TMB-version")
+  cur.TMB.version <- get.version("TMB")
+  if (!file.exists(file)) {
+    writeLines(cur.TMB.version, con = file)
+  }
+  spict.TMB.version <- readLines(file)
+  if (!identical(spict.TMB.version, cur.TMB.version)) {
+    warning("Package version inconsistency detected.\n",
+            "spict was built with TMB version ", spict.TMB.version,
+            "\n", "Current TMB version is ", cur.TMB.version,
+            "\n", "Please re-install 'spict' from source using remotes::install_github('DTUAqua/spict/spict')")
+  }
 }

--- a/spict/man/check.inp.Rd
+++ b/spict/man/check.inp.Rd
@@ -84,6 +84,7 @@ Example: Biomass prior of 200 in 1985
 - Settings/Options/Preferences
 
 \itemize{
+\item{"inp$nspinup"}{Number of time steps used for spin-up (burn-in) period. Default: 0. }
 \item{"inp$maninterval"}{ Start and end time of management period. Default: One year interval starting at the beginning of the new year after the last observation. Example: inp$maninterval <- c(2020.25,2021.25)}
 \item{"inp$maneval"}{ Time for the estimation of predicted model states (biomass and fishing mortality), which can be used to evaluate the implications of management scenarios. Default: At the end of the management interval \code{inp$maninterval[2]}. Example: inp$maneval <- 2021.25}
  \item{"inp$timepredc"}{ Deprecated: Predict accummulated catch in the interval starting at $timepredc and $dtpredc into the future. Default depends on \code{inp$maninterval}.}


### PR DESCRIPTION
Using `indxmin <- which.min(!inp$isspinup)` in plotting functions needed to account for different time series length when `rep` includes management scenarios. 

Using `indxmin` makes use of `!inp$isspinup` redundant.